### PR TITLE
Implemented virtual receive function

### DIFF
--- a/gr-Interfaces/include/Interfaces/queue_len_deframer_sink_b.h
+++ b/gr-Interfaces/include/Interfaces/queue_len_deframer_sink_b.h
@@ -1,17 +1,17 @@
 /* -*- c++ -*- */
-/* 
+/*
  * Copyright 2016 <+YOU OR YOUR COMPANY+>.
- * 
+ *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3, or (at your option)
  * any later version.
- * 
+ *
  * This software is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this software; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street,
@@ -47,6 +47,7 @@ namespace gr {
        * creating new instances.
        */
       static sptr make(char preamble, bool rxlog);
+      virtual char * receive();
     };
 
   } // namespace Interfaces


### PR DESCRIPTION
Extend functionality of python object to allow the Interfaces.queue_len_deframer_sink_b block to return and remove the top packet received.
